### PR TITLE
add status action to show vms on the cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
 install:
-        - pip3 install pyvmomi==6.7.0.2018.9 pyyaml pytest pylint
+        - pip3 install pyvmomi==6.7.0.2018.9 pyyaml PTable pytest pylint
 
 script: pylint --errors-only *.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache python3 cdrkit
 
 RUN mkdir -p /app
 
-RUN pip3 install --no-cache-dir pyvmomi==6.7.0.2018.9 pyyaml
+RUN pip3 install --no-cache-dir pyvmomi==6.7.0.2018.9 pyyaml PTable
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ alias pyvomi="sudo docker run -ti --rm --name pyvomi \
 ### Python virtualenv
 
 ```console
-$ pip3 install --no-cache-dir pyvmomi==6.7.0.2018.9 pyyaml
+$ pip install -r requirements.txt
 ```
 
 ## Options
@@ -136,29 +136,49 @@ File option | CLI option | Action | Description | Default
 
 ## CLI Example
 
+### deploy
+
 We assume you are working in the repository directory.
 
 Deploy with the default parameters:
 
 ```console
-$ pyvomi caasp-vmware.py deploy -stack_name example
-```
-
-Destroy the deployment:
-
-```console
-$ pyvomi caasp-vmware.py destroy -stack_name example
+$ pyvomi caasp-vmware.py deploy --stack-name example
 ```
 
 Deploy 3 masters, 10 workers, override default RAM and CPU for workers:
 
 ```console
-$ pyvomi caasp-vmware.py deploy -stack_name example \
+$ pyvomi caasp-vmware.py deploy --stack-name example \
    --master-count 3 \
    --worker-count 10 \
    --worker-ram 16384 \
    --worker-cpu 4
 ```
+
+### status
+
+Show the status of a deployed stack:
+
+```console
+$ pyvomi caasp-vmware.py status --stack-name example
+```
+
+Show the status of every virtual machines in the VMware cluster:
+
+```console
+$ pyvomi caasp-vmware.py status --show-all
+```
+
+### destroy
+
+Destroy the deployment:
+
+```console
+$ pyvomi caasp-vmware.py destroy --stack-name example
+```
+
+### image management
 
 List images in the image directory *media_dir*
 
@@ -216,12 +236,12 @@ usage: caasp-vmware.py [-h] [--var-file [VAR_FILE]]
                        [--worker-count [WORKER_COUNT]]
                        [--worker-prefix [WORKER_PREFIX]]
                        [--worker-cpu [WORKER_CPU]] [--worker-ram [WORKER_RAM]]
-                       [{plan,deploy,destroy,listimages,pushimage,deleteimage}]
+                       [{plan,deploy,destroy,status,listimages,pushimage,deleteimage}]
 
 Process args
 
 positional arguments:
-  {plan,deploy,destroy,listimages,pushimage,deleteimage}
+  {plan,deploy,destroy,status,listimages,pushimage,deleteimage}
                         Execution command
 
 optional arguments:
@@ -268,7 +288,7 @@ optional arguments:
                         Admin CPUs
   --admin-ram [ADMIN_RAM]
                         Admin RAM
-  --master_count [MASTER_COUNT]
+  --master-count [MASTER_COUNT]
                         Number of masters
   --master-prefix [MASTER_PREFIX]
                         Master node name prefix
@@ -276,7 +296,7 @@ optional arguments:
                         Master CPUs
   --master-ram [MASTER_RAM]
                         Master RAM
-  --worker_count [WORKER_COUNT]
+  --worker-count [WORKER_COUNT]
                         Number of workers
   --worker-prefix [WORKER_PREFIX]
                         Worker node name prefix
@@ -284,4 +304,5 @@ optional arguments:
                         Worker CPUs
   --worker-ram [WORKER_RAM]
                         Worker RAM
+  --show-all            Show every VMs on the cluster, can take long time
 ```

--- a/caasp-vmware
+++ b/caasp-vmware
@@ -3,7 +3,7 @@
 set -eu
 SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export VENVDIR=${WORKSPACE:-~}/py3venv
-$VENVDIR/bin/pip3 install pyvmomi==6.7.0.2018.9 pyyaml
+$VENVDIR/bin/pip3 install -r requirements.txt
 
 # use unbuffered output
 stdbuf -i0 -o0 -e0  ${VENVDIR}/bin/python3 -u ${SDIR}/caasp-vmware.py $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyvmomi==6.7.0.2018.9
 pyyaml
+PTable


### PR DESCRIPTION
There is a new requirement for "PTable"

```
$ pyvomi caasp-vmware.py status --stack-name 110k8s
TASK: log in to vcenter
INFO: connecting...
INFO: connection succeeded
TASK: show virtual machines and templates
+------------------------+----------+---------------+------------+----------------------+----------+
|          Name          | Hostname |   IP Address  |   State    |     VMware Tools     | Template |
+------------------------+----------+---------------+------------+----------------------+----------+
| caasp-worker-110k8s001 | vm153249 | 10.10.10.249 |  running   |  guestToolsRunning   |  False   |
| caasp-master-110k8s000 | vm153051 |  10.10.10.51 |  running   |  guestToolsRunning   |  False   |
| caasp-worker-110k8s000 | vm153247 | 10.10.10.247 |  running   |  guestToolsRunning   |  False   |
| caasp-admin-110k8s000  | vm153104 | 10.10.10.104 |  running   |  guestToolsRunning   |  False   |
|  caasp-master-110k8s   |   None   |      None     | notRunning | guestToolsNotRunning |   True   |
|  caasp-worker-110k8s   |   None   |      None     | notRunning | guestToolsNotRunning |   True   |
|   caasp-admin-110k8s   |   None   |      None     | notRunning | guestToolsNotRunning |   True   |
+------------------------+----------+---------------+------------+----------------------+----------+
```

```
$ pyvomi caasp-vmware.py status --show-all
```

Signed-off-by: Ludovic Cavajani <lcavajani@suse.com>